### PR TITLE
Corrected spelling of 'succesful' to 'successful'

### DIFF
--- a/tools/zipalign/ZipAlign.cpp
+++ b/tools/zipalign/ZipAlign.cpp
@@ -212,7 +212,7 @@ static int verify(const char* fileName, int alignment, bool verbose,
     }
 
     if (verbose)
-        printf("Verification %s\n", foundBad ? "FAILED" : "succesful");
+        printf("Verification %s\n", foundBad ? "FAILED" : "successful");
 
     return foundBad ? 1 : 0;
 }


### PR DESCRIPTION
I have been scripting around this tool lately and noticed that the success message had a small spelling error. Corrected the string.
